### PR TITLE
Update 08-cuisine-type.sh to incl. moving to newly created dir

### DIFF
--- a/2-manipulation/08-cuisine-type.sh
+++ b/2-manipulation/08-cuisine-type.sh
@@ -2,4 +2,5 @@
 # Cuisine Type 🥘
 
 mkdir american
+cd american
 touch grilled-cheese.txt


### PR DESCRIPTION
In the instructions for 08. Cuisine Type, it asks us to create a new directory inside recipe folder with the cuisine name (in this case american), then asks us to create a blank text file inside (which I assume will be the newly created folder).

In the solution, cd'ing into the new american directory was missing, making it redundant.

Hope this helps!