### PR TITLE
fix: remove the hyperlink in the "Welcome" sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 <br>
 
-Welcome to [the Command Line](https://www.codedex.io/command-line) GitHub repo! We are super excited to have you. Here, you will find all the solutions to the Codédex exercises. Feel free to make pull requests to add your own twists on the exercises!
+Welcome to the Command Line GitHub repo! We are super excited to have you. Here, you will find all the solutions to the Codédex exercises. Feel free to make pull requests to add your own twists on the exercises!
 
 ### Website: www.codedex.io/command-line
 


### PR DESCRIPTION
## Description
This PR removes the hyperlink shown in the "Welcome" sentence. This would lessen the confusion of readers.  
### Issue
Closes #9 